### PR TITLE
Set default envmap to env_cubemap

### DIFF
--- a/mp/src/materialsystem/stdshaders/pbr_dx9.cpp
+++ b/mp/src/materialsystem/stdshaders/pbr_dx9.cpp
@@ -96,6 +96,10 @@ BEGIN_VS_SHADER(PBR, "PBR shader")
 		if (!params[BUMPMAP]->IsDefined())
 			params[BUMPMAP]->SetStringValue("dev/flat_normal");
 
+		// PBR relies heavily on envmaps
+		if (!params[ENVMAP]->IsDefined())
+			params[ENVMAP]->SetStringValue("env_cubemap");
+
 		// Check if the hardware supports flashlight border color
 		if (g_pHardwareConfig->SupportsBorderColor())
 		{


### PR DESCRIPTION
So if someone forgets to specify one, the material will still look good