### PR TITLE
Fix SP crash on mat_reloadallmaterials

### DIFF
--- a/mp/src/materialsystem/stdshaders/pbr_dx9.cpp
+++ b/mp/src/materialsystem/stdshaders/pbr_dx9.cpp
@@ -604,7 +604,7 @@ BEGIN_VS_SHADER(PBR, "PBR shader")
             flParams[0] = GetFloatParam(info.parallaxDepth, params, 3.0f);
             // Parallax Center (the height at which it's not moved)
             flParams[1] = GetFloatParam(info.parallaxCenter, params, 3.0f);
-            pShaderAPI->SetPixelShaderConstant(40, flParams, 1);
+            pShaderAPI->SetPixelShaderConstant(27, flParams, 1);
 
         }
 

--- a/mp/src/materialsystem/stdshaders/pbr_ps30.fxc
+++ b/mp/src/materialsystem/stdshaders/pbr_ps30.fxc
@@ -44,7 +44,7 @@ PixelShaderLightInfo cLightInfo[3]              : register(PSREG_LIGHT_INFO_ARRA
 const float4 g_BaseColor                        : register(PSREG_SELFILLUMTINT);
 
 #if PARALLAXOCCLUSION
-const float4 g_ParallaxParms                    : register( c40 );
+const float4 g_ParallaxParms                    : register( c27 );
 #define PARALLAX_DEPTH                          g_ParallaxParms.r
 #define PARALLAX_CENTER                         g_ParallaxParms.g
 #endif


### PR DESCRIPTION
SP doesn' support more than 32 shader constants. Too bad!  
