### PR TITLE
All sorts of tints

### DIFF
--- a/mp/src/materialsystem/stdshaders/pbr_ps20b.fxc
+++ b/mp/src/materialsystem/stdshaders/pbr_ps20b.fxc
@@ -9,6 +9,7 @@
 // STATIC: "LIGHTMAPPED"                "0..1"
 // STATIC: "EMISSIVE"                   "0..1"
 // STATIC: "SPECULAR"                   "0..1"
+// STATIC: "BLENDTINTBYBASEALPHA"       "0..1"
 
 // DYNAMIC: "WRITEWATERFOGTODESTALPHA"  "0..1"
 // DYNAMIC: "PIXELFOGTYPE"              "0..1"
@@ -40,6 +41,13 @@ const float4 g_FlashlightPos                    : register(PSREG_FLASHLIGHT_POSI
 const float4x4 g_FlashlightWorldToTexture       : register(PSREG_FLASHLIGHT_TO_WORLD_TEXTURE);
 PixelShaderLightInfo cLightInfo[3]              : register(PSREG_LIGHT_INFO_ARRAY);         // 2 registers each - 6 registers total (4th light spread across w's)
 const float4 g_BaseColor                        : register(PSREG_SELFILLUMTINT);
+#if EMISSIVE
+const float4 g_EmissionTint                     : register(PSREG_SELFILLUM_SCALE_BIAS_EXP);
+#endif
+
+const float4 g_ParallaxParms                    : register( c27 );
+
+#define BLENDTINTCOLOROVERBASE                  g_ParallaxParms.w
 
 sampler BaseTextureSampler          : register(s0);     // Base map, selfillum in alpha
 sampler NormalTextureSampler        : register(s1);     // Normal map
@@ -76,12 +84,21 @@ float4 main(PS_INPUT i) : COLOR
     float2 correctedTexCoord = i.baseTexCoord;
 
     float4 albedo = tex2D(BaseTextureSampler, correctedTexCoord);
-    albedo.xyz *= g_BaseColor;
+
+#if BLENDTINTBYBASEALPHA
+        float3 tintedColor = albedo.rgb * g_BaseColor.rgb;
+        tintedColor = lerp(tintedColor, g_BaseColor.rgb, BLENDTINTCOLOROVERBASE);
+        albedo.rgb = lerp(albedo.rgb, tintedColor, albedo.a);
+#else
+        albedo.rgb *= g_BaseColor.rgb;
+#endif
 
     float3 mrao = tex2D(MRAOTextureSampler, correctedTexCoord).xyz;
     float metalness = mrao.x, roughness = mrao.y, ambientOcclusion = mrao.z;
 #if EMISSIVE
     float3 emission = tex2D(EmissionTextureSampler, correctedTexCoord).xyz;
+    emission *= g_EmissionTint.xyz;
+    emission *= g_EmissionTint.a;
 #endif
 #if SPECULAR
     float3 specular = tex2D(SpecularTextureSampler, correctedTexCoord).xyz;
@@ -95,10 +112,18 @@ float4 main(PS_INPUT i) : COLOR
 
     float3 specularReflectionVector = 2.0 * lightDirectionAngle * normal - outgoingLightDirection; // Lr
 
-#if SPECULAR
-    float3 fresnelReflectance = specular.rgb; // F0
-#else
     float3 dielectricCoefficient = 0.04; //F0 dielectric
+#if SPECULAR
+    float3 specTinted = specular.rgb;
+#if BLENDTINTBYBASEALPHA
+    float3 tintedSpecColor = specTinted * g_BaseColor.rgb;
+    tintedSpecColor = lerp(tintedSpecColor, g_BaseColor.rgb, BLENDTINTCOLOROVERBASE);
+    specTinted = lerp(specTinted, tintedSpecColor, albedo.a);
+#else
+    specTinted *= g_BaseColor.rgb;
+#endif
+    float3 fresnelReflectance = specular.rgb > dielectricCoefficient ? specTinted : specular.rgb; // F0
+#else
     float3 fresnelReflectance = lerp(dielectricCoefficient, albedo.rgb, metalness); // F0
 #endif
 
@@ -176,10 +201,11 @@ float4 main(PS_INPUT i) : COLOR
 
     float fogFactor = CalcPixelFogFactor(PIXELFOGTYPE, g_FogParams, g_EyePos.z, i.worldPos.z, i.projPos.z);
 
+    float alpha = g_BaseColor.a;
 #if WRITEWATERFOGTODESTALPHA && (PIXELFOGTYPE == PIXEL_FOG_TYPE_HEIGHT)
-    float alpha = fogFactor;
-#else
-    float alpha = albedo.a;
+    alpha = fogFactor;
+#elif !BLENDTINTBYBASEALPHA
+    alpha *= albedo.a;
 #endif
 
     bool bWriteDepthToAlpha = (WRITE_DEPTH_TO_DESTALPHA != 0) && (WRITEWATERFOGTODESTALPHA == 0);

--- a/mp/src/materialsystem/stdshaders/pbr_ps30.fxc
+++ b/mp/src/materialsystem/stdshaders/pbr_ps30.fxc
@@ -11,6 +11,7 @@
 // STATIC: "EMISSIVE"                   "0..1"
 // STATIC: "SPECULAR"                   "0..1"
 // STATIC:  "PARALLAXOCCLUSION"         "0..1"
+// STATIC: "BLENDTINTBYBASEALPHA"       "0..1"
 
 // DYNAMIC: "WRITEWATERFOGTODESTALPHA"  "0..1"
 // DYNAMIC: "PIXELFOGTYPE"              "0..1"
@@ -42,12 +43,16 @@ const float4 g_FlashlightPos                    : register(PSREG_FLASHLIGHT_POSI
 const float4x4 g_FlashlightWorldToTexture       : register(PSREG_FLASHLIGHT_TO_WORLD_TEXTURE);
 PixelShaderLightInfo cLightInfo[3]              : register(PSREG_LIGHT_INFO_ARRAY);         // 2 registers each - 6 registers total (4th light spread across w's)
 const float4 g_BaseColor                        : register(PSREG_SELFILLUMTINT);
+#if EMISSIVE
+const float4 g_EmissionTint                     : register(PSREG_SELFILLUM_SCALE_BIAS_EXP);
+#endif
 
-#if PARALLAXOCCLUSION
 const float4 g_ParallaxParms                    : register( c27 );
+#if PARALLAXOCCLUSION
 #define PARALLAX_DEPTH                          g_ParallaxParms.r
 #define PARALLAX_CENTER                         g_ParallaxParms.g
 #endif
+#define BLENDTINTCOLOROVERBASE                  g_ParallaxParms.w
 
 sampler BaseTextureSampler          : register(s0);     // Base map, selfillum in alpha
 sampler NormalTextureSampler        : register(s1);     // Normal map
@@ -105,12 +110,21 @@ float4 main(PS_INPUT i) : COLOR
     float3 normal = normalize(mul(textureNormal, normalBasis)); // World Normal
 
     float4 albedo = tex2D(BaseTextureSampler, correctedTexCoord);
-    albedo.xyz *= g_BaseColor;
+
+#if BLENDTINTBYBASEALPHA
+    float3 tintedSpecColor = albedo.rgb * g_BaseColor.rgb;
+    tintedSpecColor = lerp(tintedSpecColor, g_BaseColor.rgb, BLENDTINTCOLOROVERBASE);
+    albedo.rgb = lerp(albedo.rgb, tintedSpecColor, albedo.a);
+#else
+    albedo.rgb *= g_BaseColor.rgb;
+#endif
 
     float3 mrao = tex2D(MRAOTextureSampler, correctedTexCoord).xyz;
     float metalness = mrao.x, roughness = mrao.y, ambientOcclusion = mrao.z;
 #if EMISSIVE
     float3 emission = tex2D(EmissionTextureSampler, correctedTexCoord).xyz;
+    emission *= g_EmissionTint.xyz;
+    emission *= g_EmissionTint.a;
 #endif
 #if SPECULAR
     float3 specular = tex2D(SpecularTextureSampler, correctedTexCoord).xyz;
@@ -123,17 +137,24 @@ float4 main(PS_INPUT i) : COLOR
 
     float3 specularReflectionVector = 2.0 * lightDirectionAngle * normal - outgoingLightDirection; // Lr
 
-#if SPECULAR
-    float3 fresnelReflectance = specular.rgb; // F0
-#else
     float3 dielectricCoefficient = 0.04; //F0 dielectric
+#if SPECULAR
+    float3 specTinted = specular.rgb;
+#if BLENDTINTBYBASEALPHA
+    float3 tintedColor = specTinted * g_BaseColor.rgb;
+    tintedColor = lerp(tintedColor, g_BaseColor.rgb, BLENDTINTCOLOROVERBASE);
+    specTinted = lerp(specTinted, tintedColor, albedo.a);
+#else
+    specTinted *= g_BaseColor.rgb;
+#endif
+    float3 fresnelReflectance = specular.rgb > dielectricCoefficient ? specTinted : specular.rgb; // F0
+#else
     float3 fresnelReflectance = lerp(dielectricCoefficient, albedo.rgb, metalness); // F0
 #endif
 
     // Start ambient
     float3 ambientLighting = 0.0;
-    if (!FLASHLIGHT)
-    {
+#if !FLASHLIGHT
         float3 diffuseIrradiance = ambientLookup(normal, EnvAmbientCube, textureNormal, i.lightmapTexCoord1And2, i.lightmapTexCoord3, LightmapSampler, g_DiffuseModulation);
         // return float4(diffuseIrradiance, 1); // testing diffuse irraciance
         float3 ambientLightingFresnelTerm = fresnelSchlick(fresnelReflectance, lightDirectionAngle); // F
@@ -151,12 +172,12 @@ float4 main(PS_INPUT i) : COLOR
         float3 specularIBL = specularIrradiance * EnvBRDFApprox(fresnelReflectance, roughness, lightDirectionAngle);
 
         ambientLighting = (diffuseIBL + specularIBL) * ambientOcclusion;
-    }
+#endif
     // End ambient
 
     // Start direct
     float3 directLighting = 0.0;
-    if (!FLASHLIGHT) {
+#if !FLASHLIGHT
         for (uint n = 0; n < NUM_LIGHTS; ++n)
         {
             float3 LightIn = normalize(PixelShaderGetLightVector(i.worldPos, cLightInfo, n));
@@ -165,12 +186,11 @@ float4 main(PS_INPUT i) : COLOR
             directLighting += calculateLight(LightIn, LightColor, outgoingLightDirection,
                     normal, fresnelReflectance, roughness, metalness, lightDirectionAngle, albedo.rgb);
         }
-    }
+#endif
     // End direct
 
     // Start flashlight
-    if (FLASHLIGHT)
-    {
+#if FLASHLIGHT
         float4 flashlightSpacePosition = mul(float4(i.worldPos, 1.0), g_FlashlightWorldToTexture);
         clip( flashlightSpacePosition.w ); // stop projected textures from projecting backwards (only really happens if they have a big FOV because they get frustum culled.)
         float3 vProjCoords = flashlightSpacePosition.xyz / flashlightSpacePosition.w;
@@ -199,7 +219,7 @@ float4 main(PS_INPUT i) : COLOR
 
         directLighting += max(0, calculateLight(flashLightIn, flashLightIntensity, outgoingLightDirection,
                 normal, fresnelReflectance, roughness, metalness, lightDirectionAngle, albedo.rgb));
-    }
+#endif
     // End flashlight
 
 float fogFactor = 0.0f;
@@ -207,13 +227,15 @@ float fogFactor = 0.0f;
 fogFactor = CalcPixelFogFactor(PIXELFOGTYPE, g_FogParams, g_EyePos.z, i.worldPos.z, i.projPos.z);
 #endif
 
-float alpha = 0.0f;
+    float alpha = g_BaseColor.a;
 #if !FLASHLIGHT
 #if WRITEWATERFOGTODESTALPHA && (PIXELFOGTYPE == PIXEL_FOG_TYPE_HEIGHT)
     alpha = fogFactor;
-#else
-    alpha = albedo.a;
+#elif !BLENDTINTBYBASEALPHA
+    alpha *= albedo.a;
 #endif
+#else
+    alpha = 0.0f;
 #endif
 
     bool bWriteDepthToAlpha = (WRITE_DEPTH_TO_DESTALPHA != 0) && (WRITEWATERFOGTODESTALPHA == 0);


### PR DESCRIPTION
Fixed:
- `$color2` not working outside lightmapped pass (in theory `$color` should work too but i haven't seen that even in VLG materials)

Added:
- `$emissiontint` - adjusts emission texture tint
- `$emissionstrength` - multiplies emission tint (useful for material proxies)
- [`$blendtintbybasealpha` and `$blendtintcoloroverbase`](https://developer.valvesoftware.com/wiki/$color#Models) for controlling `$color2` (this adds another static combo)